### PR TITLE
Fixes a glitch of opening editor at first click

### DIFF
--- a/src/polygon_selector.js
+++ b/src/polygon_selector.js
@@ -35,6 +35,9 @@ annotorious.plugin.PolygonSelector.Selector.prototype.init = function(annotator,
 
   /** @private **/
   this._anchor;
+
+  /** @private **/
+  this._last;
   
   /** @private **/
   this._points = [];
@@ -140,15 +143,22 @@ annotorious.plugin.PolygonSelector.Selector.prototype._attachListeners = functio
       event.offsetY = event.layerY;
     }
 
-    if (isClosable(event.offsetX, event.offsetY)) {
-      self._enabled = false;
-      refresh(self._anchor);
+    if (!this._last) this._last = { x: event.offsetX, y: event.offsetY };
 
-      self._annotator.fireEvent('onSelectionCompleted',
-        { mouseEvent: event, shape: self.getShape(), viewportBounds: self.getViewportBounds() }); 
-    } else {
-      self._points.push({ x: event.offsetX, y: event.offsetY });
+    if (!(this._last.x == event.offsetX && this._last.y == event.offsetY)) {
+      console.log(isClosable(event.offsetX, event.offsetY));
+      if (isClosable(event.offsetX, event.offsetY)) {
+        self._enabled = false;
+        refresh(self._anchor);
+
+        self._annotator.fireEvent('onSelectionCompleted',
+          { mouseEvent: event, shape: self.getShape(), viewportBounds: self.getViewportBounds() }); 
+      } else {
+        self._points.push({ x: event.offsetX, y: event.offsetY });
+      }
     }
+    this._last = { x: event.offsetX, y: event.offsetY };
+
   });
 }
 


### PR DESCRIPTION
When the user draws more than three polygons, the editor was opening in the first click of the third polygon.

It was happening because Annotorious is sending two clicks in the second polygon, three clicks in the third, and so on. The isClosed function checks if it's at least the third point and if it's 5 pixels close to the _anchor point, so it was causing the window to open wrongly.

My contribution is a workaround to check if the click is the same as the last one, so it doesn't call the isClosed function if so.

It doesn't correct the multiple-click event issue (I think it's a core Annotorious glitch), but it fixes the expected behavior.
